### PR TITLE
Add 'LAST_ACTIVITY' field for users

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE users(
     name TEXT NOT NULL,
     surname TEXT NOT NULL,
     password TEXT NOT NULL
+    last_active INTEGER,
 );
 
 CREATE TABLE chats(

--- a/src/db.rs
+++ b/src/db.rs
@@ -31,6 +31,18 @@ pub trait Retriever {
     /// ```
     fn get_users(&self) -> Result<Vec<entities::User>, DatabaseError>;
 
+    /// Get the user info
+    ///
+    /// The method reads the list of users, which are avaliable in the
+    /// database and returns the one with the given ID.
+    ///
+    /// # Examples
+    /// ```
+    /// let driver = SQLite::new("data.db");
+    /// for value in driver.get_user(0).unwrap() {
+    ///     println!("User with the name found: {}", value.name);
+    /// }
+    /// ```
     fn get_user(&self, user_id: entities::UserID) -> Result<entities::User, DatabaseError>;
 
     /// Get a list of chats, available for the user
@@ -177,4 +189,20 @@ pub trait Inserter {
         chat_id: entities::ChatID,
         user_id: entities::UserID,
     ) -> Option<DatabaseError>;
+
+    /// Update the last activity timestamp of the user
+    ///
+    /// This method gets the current time as a UNIX timestamp and updates the
+    /// 'last_active' field of the users table for the given user_id
+    ///
+    /// # Examples
+    /// ```
+    /// let driver = drivers::SQLite::new("database.db");
+    /// if let Some(error) = driver.update_last_activity(0) {
+    ///     println!("{}", error.message);
+    /// } else {
+    ///     println!("No errors");
+    /// }
+    /// ```    
+    fn update_last_activity(&self, user_id: entities::UserID) -> Option<DatabaseError>;
 }

--- a/src/db/entities.rs
+++ b/src/db/entities.rs
@@ -10,16 +10,24 @@ pub struct User {
     pub name: String,
     pub surname: String,
     pub password: String,
+    pub last_active: Duration,
 }
 
 impl User {
     /// Create a new User instance
-    pub fn new(id: UserID, name: String, surname: String, password: String) -> User {
+    pub fn new(
+        id: UserID,
+        name: String,
+        surname: String,
+        password: String,
+        last_active: Duration,
+    ) -> User {
         User {
             id,
             name,
             surname,
             password,
+            last_active,
         }
     }
 }


### PR DESCRIPTION
This pull request adds a new field to the USERS table along with the code that handles it. A new method, which updates the last activity timestamp for the given user with ID is added.